### PR TITLE
Local run in a single Docker container

### DIFF
--- a/example/simple.py
+++ b/example/simple.py
@@ -18,3 +18,5 @@ class SimpleBehavior(TaskSet):
 
 class MyLocust(HttpLocust):
     task_set = SimpleBehavior
+#    min_wait = 0
+#    max_wait = 0

--- a/example/simple.py
+++ b/example/simple.py
@@ -18,5 +18,5 @@ class SimpleBehavior(TaskSet):
 
 class MyLocust(HttpLocust):
     task_set = SimpleBehavior
-#    min_wait = 0
-#    max_wait = 0
+    min_wait = 0
+    max_wait = 0

--- a/src/app.py
+++ b/src/app.py
@@ -102,10 +102,10 @@ def bootstrap(_return=0):
             except ValueError as v_err:
                 logger.error(v_err)
 
-    elif role == 'single':
+    elif role == 'local':
         automatic = convert_str_to_bool(os.getenv('AUTOMATIC', str(False)))
         logger.info('Automatic run: {auto}'.format(auto=automatic))
-        os.environ["MASTER_HOST"] = '127.0.0.1'
+        if not os.environ.get('MASTER_HOST'): os.environ["MASTER_HOST"] = '127.0.0.1'
         os.environ["ROLE"] = 'master'
         bootstrap(1)
         os.environ["ROLE"] = 'slave'

--- a/src/app.py
+++ b/src/app.py
@@ -176,7 +176,7 @@ def get_locust_file():
         else:
             logger.info('Load test script from local machine')
             if file.endswith('.py'):
-                file_name = '/'.join(['script', file])
+                file_name = file if file.startswith('/') else  '/'.join(['script', file])
     logger.info('load test file: {f}'.format(f=file_name))
     return file_name
 

--- a/src/app.py
+++ b/src/app.py
@@ -109,11 +109,14 @@ def bootstrap(_return=0):
       automatic = convert_str_to_bool(os.getenv('AUTOMATIC', str(False)))
       os.environ["MASTER_HOST"] = '127.0.0.1'
 
-      for role in ['master', 'slave', 'controller']:
+      for role in ['master', 'slave']:
         os.environ['ROLE'] = role
         bootstrap(1)
 
-      if automatic: sys.exit(0)
+      if automatic:
+        os.environ['ROLE'] = 'controller'
+        bootstrap(1)
+        sys.exit(0)
 
     else:
         raise RuntimeError('Invalid ROLE value. Valid Options: master, slave, controller.')

--- a/src/app.py
+++ b/src/app.py
@@ -15,14 +15,14 @@ logging.basicConfig()
 logger = logging.getLogger('bootstrap')
 
 
-def bootstrap(role='', _return=0):
+def bootstrap(_return=0):
     """
     Initialize role of running docker container.
     master: web interface / API.
     slave: node that load test given url.
     controller: node that control the automatic run.
     """
-    role = role if role else get_or_raise('ROLE')
+    role = get_or_raise('ROLE')
     logger.info('Role :{role}'.format(role=role))
 
     if role == 'master':
@@ -105,10 +105,14 @@ def bootstrap(role='', _return=0):
     elif role == 'single':
         automatic = convert_str_to_bool(os.getenv('AUTOMATIC', str(False)))
         logger.info('Automatic run: {auto}'.format(auto=automatic))
-        bootstrap("master", 1)
-        bootstrap("slave", 1)
+        os.environ["MASTER_HOST"] = '127.0.0.1'
+        os.environ["ROLE"] = 'master'
+        bootstrap(1)
+        os.environ["ROLE"] = 'slave'
+        bootstrap(1)
         if automatic:
-          bootstrap("controller", 1)
+          os.environ["ROLE"] = 'controller'
+          bootstrap(1)
           sys.exit(0)
 
     else:

--- a/src/app.py
+++ b/src/app.py
@@ -104,13 +104,16 @@ def bootstrap(_return=0):
         except ValueError as v_err:
             logger.error(v_err)
 
-        sys.exit(0)
 
     elif role == 'standalone':
+      automatic = convert_str_to_bool(os.getenv('AUTOMATIC', str(False)))
       os.environ["MASTER_HOST"] = '127.0.0.1'
+ 
       for role in ['master', 'slave', 'controller']:
         os.environ['ROLE'] = role
         bootstrap(1)
+
+      if automatic: sys.exit(0)
 
     else:
         raise RuntimeError('Invalid ROLE value. Valid Options: master, slave, controller.')

--- a/src/app.py
+++ b/src/app.py
@@ -108,7 +108,7 @@ def bootstrap(_return=0):
     elif role == 'standalone':
       automatic = convert_str_to_bool(os.getenv('AUTOMATIC', str(False)))
       os.environ["MASTER_HOST"] = '127.0.0.1'
- 
+
       for role in ['master', 'slave', 'controller']:
         os.environ['ROLE'] = role
         bootstrap(1)

--- a/src/tests/test_bootstrap.py
+++ b/src/tests/test_bootstrap.py
@@ -50,14 +50,14 @@ class TestBootstrap(TestCase):
         os.environ['AUTOMATIC'] = '1'
 
         with mock.patch('src.app.get_locust_file') as file:
-          bootstrap()
-          self.assertTrue(mocked_popen.called)
+            bootstrap()
+            self.assertTrue(mocked_popen.called)
 
         os.environ['AUTOMATIC'] = '0'
         with mock.patch('src.app.get_locust_file') as file:
-          bootstrap()
-          self.assertTrue(mocked_popen.called)
-          self.assertTrue(mocked_exit.called)
+            bootstrap()
+            self.assertTrue(mocked_popen.called)
+            self.assertTrue(mocked_exit.called)
 
     @mock.patch('time.sleep')
     @mock.patch('os.makedirs')

--- a/src/tests/test_bootstrap.py
+++ b/src/tests/test_bootstrap.py
@@ -42,6 +42,23 @@ class TestBootstrap(TestCase):
         bootstrap()
         self.assertFalse(mocked_timeout.called)
 
+    @mock.patch('subprocess.Popen')
+    @mock.patch('sys.exit')
+    def test_standalone(self, mocked_popen, mocked_exit):
+        os.environ['ROLE'] = 'standalone'
+        os.environ['TARGET_HOST'] = 'https://test.com'
+        os.environ['AUTOMATIC'] = '1'
+
+        with mock.patch('src.app.get_locust_file') as file:
+          bootstrap()
+          self.assertTrue(mocked_popen.called)
+
+        os.environ['AUTOMATIC'] = '0'
+        with mock.patch('src.app.get_locust_file') as file:
+          bootstrap()
+          self.assertTrue(mocked_popen.called)
+          self.assertTrue(mocked_exit.called)
+
     @mock.patch('time.sleep')
     @mock.patch('os.makedirs')
     @mock.patch('__builtin__.open')

--- a/src/tests/test_bootstrap.py
+++ b/src/tests/test_bootstrap.py
@@ -48,16 +48,16 @@ class TestBootstrap(TestCase):
         os.environ['ROLE'] = 'standalone'
         os.environ['TARGET_HOST'] = 'https://test.com'
         os.environ['AUTOMATIC'] = '1'
+        os.environ['LOC'] = '1'
 
-        with mock.patch('src.app.get_locust_file') as file:
-            bootstrap()
-            self.assertTrue(mocked_popen.called)
+        with mock.patch('src.app.get_locust_file'):
+          bootstrap()
+          self.assertTrue(mocked_popen.called)
 
-        os.environ['AUTOMATIC'] = '0'
-        with mock.patch('src.app.get_locust_file') as file:
-            bootstrap()
-            self.assertTrue(mocked_popen.called)
-            self.assertTrue(mocked_exit.called)
+          os.environ['AUTOMATIC'] = '0'
+          bootstrap()
+          self.assertTrue(mocked_popen.called)
+          self.assertTrue(mocked_exit.called)
 
     @mock.patch('time.sleep')
     @mock.patch('os.makedirs')


### PR DESCRIPTION
This would enable single-instance automatic runs without docker-compose, e.g.: 
```docker run -ti -v ~/GHE/docker-locust/example:/opt/script -e TARGET_HOST=http://example.com -e LOCUST_FILE=./simple.py -e ROLE=local -e AUTOMATIC=1 -e DURATION=10 -e HATCH_RATE=1 -e USERS=2 docker-locust```

```run --net=host -ti -v ~/GHE/docker-locust/example:/opt/script -e TARGET_HOST=http://localhost -e LOCUST_FILE=./simple.py -e ROLE=local docker-locust```

Needs detailed review.