### PR TITLE
Enforce python3 for the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.opensource.zalan.do/stups/ubuntu
+FROM registry.opensource.zalan.do/stups/ubuntu:18.04-15
 
 #=======================
 # General Configuration
 #=======================
 ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-RUN apt-get update && apt-get install -y jq python-dev python-zmq python-pip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y jq python3-dev python3-zmq python3-pip && rm -rf /var/lib/apt/lists/*
 
 #==============
 # Expose Ports
@@ -17,7 +17,7 @@ EXPOSE 5558
 # Install dependencies
 #======================
 COPY requirements.txt /tmp/
-RUN pip install -r /tmp/requirements.txt
+RUN pip3 install -r /tmp/requirements.txt
 
 #=====================
 # Start docker-locust

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ autopep8==1.3.3
 boto3==1.4.7
 coverage==4.4.1
 enum34==1.1.6
-flake8>=2.5.1,<2.6
+flake8==3.5.0
+pycodestyle<2.4.0
 locustio==0.8.1
 mock==2.0.0
 nose==1.3.7

--- a/src/app.py
+++ b/src/app.py
@@ -316,18 +316,18 @@ def get_files():
         return files
 
 
-def convert_str_to_bool(str):
+def convert_str_to_bool(string):
     """
     Convert string to boolean.
 
-    :param str: given string
-    :type str: str
+    :param string: given string
+    :type string: str
     :return: converted string
     :rtype: bool
     """
-    if isinstance(str, basestring):
-        return str.lower() in ('yes', 'true', 't', '1')
-    else:
+    try:
+        return string.lower() in ('yes', 'true', 't', '1')
+    except AttributeError:
         return False
 
 

--- a/src/tests/test_bootstrap.py
+++ b/src/tests/test_bootstrap.py
@@ -5,7 +5,6 @@ from unittest import TestCase
 import mock
 
 import requests_mock
-import builtins
 
 from src.app import bootstrap
 

--- a/src/tests/test_bootstrap.py
+++ b/src/tests/test_bootstrap.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 import mock
 
 import requests_mock
+import builtins
 
 from src.app import bootstrap
 
@@ -63,7 +64,7 @@ class TestBootstrap(TestCase):
 
     @mock.patch('time.sleep')
     @mock.patch('os.makedirs')
-    @mock.patch('__builtin__.open')
+    @mock.patch('builtins.open')
     @requests_mock.Mocker()
     def test_valid_controller_automatic(self, mocked_timeout, mocked_dir, mocked_open, mocked_request):
         os.environ['ROLE'] = 'controller'
@@ -93,7 +94,7 @@ class TestBootstrap(TestCase):
 
     @mock.patch('time.sleep')
     @mock.patch('os.makedirs')
-    @mock.patch('__builtin__.open')
+    @mock.patch('builtins.open')
     @requests_mock.Mocker()
     def test_slaves_not_fully_connected(self, mocked_timeout, mocked_dir, mocked_open, mocked_request):
         os.environ['ROLE'] = 'controller'


### PR DESCRIPTION
This PR converts all uses of python to python3 in the Dockerfile, and
converts each respective python file to be compatible with python3.

There is no backwards compatibility for python versions here, in case
such is needed a more sophisticated solution is needed.

References #80