### PR TITLE
Fix shebang to point to python3

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import logging
 


### PR DESCRIPTION
Fixes the shebang to point to python3 instead of python2.