### PR TITLE
Run example scenario before pushing docker image to opensource registry

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -20,7 +20,7 @@ pipeline:
   - desc: Run smoke test
     cmd: |
         echo "Deploy image locally and run simple scenario"
-        ./local.sh deploy --target=https://google.com --locust-file=./example/simple.py --slaves=2 --mode=auto --users=2 --hatch-rate=1 --duration=10
+        ./local.sh deploy --target=https://google.com --locust-file=./example/simple.py --slaves=2 --mode=auto --users=2 --hatch-rate=1 --duration=5
         ls -l reports | grep reports.html || exit 1
         ls -l reports | grep reports.csv || exit 1
   - desc: Push docker image

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -21,9 +21,7 @@ pipeline:
     cmd: |
         echo "Deploy image locally and run simple scenario"
         ./local.sh deploy --target=https://google.com --locust-file=./example/simple.py --slaves=2 --mode=auto --users=2 --hatch-rate=1 --duration=5
-        # check if report html file exists
-        ls -l reports | grep reports.html || exit 1
-        # check if file size is larger than 0
+        # check if file exists and size is larger than 0
         [ -s reports/reports.html ] || exit 1
         # check if RPS value is greater than 0
         cat reports/reports.html | grep 'RPS:' | cut -c 17- | awk -F'</strong' {'print $1">0"'} | bc -l | grep 1 || exit 1

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -21,6 +21,8 @@ pipeline:
     cmd: |
         echo "Deploy image locally and run simple scenario"
         ./local.sh deploy --target=https://google.com --locust-file=./example/simple.py --slaves=2 --mode=auto --users=2 --hatch-rate=1 --duration=10
+        ls -l reports | grep reports.html || exit 1
+        ls -l reports | grep reports.csv || exit 1
   - desc: Push docker image
     cmd: |
         echo "Push docker image"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -21,8 +21,12 @@ pipeline:
     cmd: |
         echo "Deploy image locally and run simple scenario"
         ./local.sh deploy --target=https://google.com --locust-file=./example/simple.py --slaves=2 --mode=auto --users=2 --hatch-rate=1 --duration=5
+        # check if report html file exists
         ls -l reports | grep reports.html || exit 1
-        ls -l reports | grep requests.csv || exit 1
+        # check if file size is larger than 0
+        [ -s reports/reports.html ] || exit 1
+        # check if RPS value is greater than 0
+        cat reports/reports.html | grep 'RPS:' | cut -c 17- | awk -F'</strong' {'print $1">0"'} | bc -l | grep 1 || exit 1
   - desc: Push docker image
     cmd: |
         echo "Push docker image"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -22,7 +22,7 @@ pipeline:
         echo "Deploy image locally and run simple scenario"
         ./local.sh deploy --target=https://google.com --locust-file=./example/simple.py --slaves=2 --mode=auto --users=2 --hatch-rate=1 --duration=5
         ls -l reports | grep reports.html || exit 1
-        ls -l reports | grep reports.csv || exit 1
+        ls -l reports | grep requests.csv || exit 1
   - desc: Push docker image
     cmd: |
         echo "Push docker image"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,18 +1,27 @@
-build_steps:
+version: "2017-09-20"
+pipeline:
+- id: build
+  type: script
+  when:
+    event: push
+    branch: master
+  commands:
   - desc: Install Docker
     cmd: |
       # Docker
       curl -fLOsS https://delivery.cloud.zalando.com/utils/ensure-docker && sh ensure-docker && rm ensure-docker
-  - desc: Build and push docker image
+  - desc: Build docker image
     cmd: |
-      IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
-      echo $IS_PR_BUILD
-      if [[ ${IS_PR_BUILD} != "true" ]]; then
-        GIT_TAG=$(git describe --tags --always --dirty)
-        IMAGE=registry-write.opensource.zalan.do/tip/docker-locust:$GIT_TAG
-        echo "Image: $IMAGE"
-        echo "Build docker image"
-        docker build -t $IMAGE --build-arg DL_IMAGE_VERSION=$GIT_TAG .
+      GIT_TAG=$(git describe --tags --always --dirty)
+      IMAGE=registry-write.opensource.zalan.do/tip/docker-locust:$GIT_TAG
+      echo "Image: $IMAGE"
+      echo "Build docker image"
+      docker build -t $IMAGE --build-arg DL_IMAGE_VERSION=$GIT_TAG .
+  - desc: Run smoke test
+    cmd: |
+        echo "Deploy image locally and run simple scenario"
+        ./local.sh deploy --target=https://google.com --locust-file=./example/simple.py --slaves=2 --mode=auto --users=2 --hatch-rate=1 --duration=10
+  - desc: Push docker image
+    cmd: |
         echo "Push docker image"
         docker push $IMAGE
-      fi


### PR DESCRIPTION
In order to reduce risk of pushing broken changes to `opensource` registry, we decided to run a smoke test before that stage. This will happen on every push to master. In case of failure, docker image will not be pushed to registry.