### PR TITLE
fixes: docker-compose does not exit

### DIFF
--- a/local.sh
+++ b/local.sh
@@ -162,7 +162,7 @@ EOF
         if $AUTOMATIC; then
             ABORT_ON_EXIT="--abort-on-container-exit"
         else
-            echo "Getting the Locust application ready on http://<docker-host-ip-address>:8089"
+            echo "Locust will be available on http://<docker-host-ip-address>:8089"
         fi
 
         (export IMAGE=$IMAGE && export TARGET_HOST=$TARGET && export LOCUST_FILE=$LOCUST_FILE && export SLAVE_NUM=$SLAVES &&

--- a/local.sh
+++ b/local.sh
@@ -158,16 +158,20 @@ EOF
         rm -rf reports
 
         echo "Deploy Locust application locally"
+
+        if $AUTOMATIC; then
+            ABORT_ON_EXIT="--abort-on-container-exit"
+        else
+            echo "Getting the Locust application ready on http://<docker-host-ip-address>:8089"
+        fi
+
         (export IMAGE=$IMAGE && export TARGET_HOST=$TARGET && export LOCUST_FILE=$LOCUST_FILE && export SLAVE_NUM=$SLAVES &&
         export AUTOMATIC=$AUTOMATIC && export USERS=$USERS && export HATCH_RATE=$HATCH_RATE &&
         export DURATION=$DURATION && export OAUTH=$OAUTH && URL=$URL && export SEND_ANONYMOUS_USAGE_INFO=$KPI &&
-        export SCOPES=$SCOPES && export BUILD_URL=$BUILD_URL && docker-compose up --abort-on-container-exit)
+        export SCOPES=$SCOPES && export BUILD_URL=$BUILD_URL && docker-compose up $ABORT_ON_EXIT)
 
         if $AUTOMATIC; then
-            sleep $DURATION
             docker cp docker_locusts_controller:/opt/reports .
-        else
-            echo "Locust application is successfully deployed. you can access http://<docker-host-ip-address>:8089"
         fi
 
     else

--- a/local.sh
+++ b/local.sh
@@ -161,17 +161,20 @@ EOF
         (export IMAGE=$IMAGE && export TARGET_HOST=$TARGET && export LOCUST_FILE=$LOCUST_FILE && export SLAVE_NUM=$SLAVES &&
         export AUTOMATIC=$AUTOMATIC && export USERS=$USERS && export HATCH_RATE=$HATCH_RATE &&
         export DURATION=$DURATION && export OAUTH=$OAUTH && URL=$URL && export SEND_ANONYMOUS_USAGE_INFO=$KPI &&
-        export SCOPES=$SCOPES && export BUILD_URL=$BUILD_URL && docker-compose up)
-
-        echo "Locust application is successfully deployed. you can access http://<docker-host-ip-address>:8089"
+        export SCOPES=$SCOPES && export BUILD_URL=$BUILD_URL && docker-compose up --abort-on-container-exit)
 
         if $AUTOMATIC; then
-            sleep 8
             sleep $DURATION
             docker cp docker_locusts_controller:/opt/reports .
+        else
+            echo "Locust application is successfully deployed. you can access http://<docker-host-ip-address>:8089"
         fi
+
     else
         echo "Run in standalone mode"
+
+        [[ ! -d "./reports" ]] && mkdir reports
+
         docker run -i --rm -v $PWD/reports:/opt/reports -v ~/.aws:/root/.aws -v $PWD/:/opt/script \
         -v $PWD/credentials:/meta/credentials -p 8089:8089 -e ROLE=standalone -e TARGET_HOST=$TARGET \
         -e LOCUST_FILE=$LOCUST_FILE -e SLAVE_MUL=$SLAVES -e AUTOMATIC=$AUTOMATIC -e USERS=$USERS \


### PR DESCRIPTION
Fixes:
- docker-compose never exits
- docker-compose in auto mode waits unnecessary time for the reports to become ready
- in plain docker the reports folder is created with root permissions

Testing:
```
rm -rf reports && \
DOCKER_COMPOSE=true && \
./local.sh deploy --target=https://google.com --locust-file=./example/simple.py \
    --slaves=2 --mode=auto --users=2 --hatch-rate=1 --duration=2 && \
ls -lan reports
```
```
rm -rf reports && \
DOCKER_COMPOSE=false && \
./local.sh deploy --target=https://google.com --locust-file=./example/simple.py \
    --slaves=2 --mode=auto --users=2 --hatch-rate=1 --duration=2 && \
ls -lan reports
```

Both commands should output something like:
```
drwxrwxr-x 2 1000 1000 4096 Jun 14 13:51 .
drwxrwxr-x 9 1000 1000 4096 Jun 14 13:51 ..
-rw-r--r-- 1    0    0  173 Jun 14 13:51 distribution.csv
-rw-r--r-- 1    0    0 3161 Jun 14 13:51 reports.html
-rw-r--r-- 1    0    0  255 Jun 14 13:51 requests.csv
-rw-r--r-- 1    0    0  585 Jun 14 13:51 requests.json
```
