### PR TITLE
Prepare for locust 0.9  upgrade. 

### DIFF
--- a/local.sh
+++ b/local.sh
@@ -77,13 +77,12 @@ EOF
     IMAGE_NAME=test_image_locust
 
     echo "Delete old reports"
-    rm -f flake8.log
     rm -f coverage.xml xunit.xml
 
     docker build -t ${IMAGE_NAME} .
 
     echo "Start coding style test (Pep8)"
-    docker run --rm ${IMAGE_NAME} /bin/bash -c "flake8 ." > flake8.log
+    docker run --rm ${IMAGE_NAME} flake8
 
     echo "Start unit test"
     docker run --rm -v $PWD:/opt/result ${IMAGE_NAME} nosetests -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ requests>=2.18.1
 requests_mock>=1.3.0
 stups-tokens>=0.7
 wget==3.2
-distutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ requests>=2.18.1
 requests_mock>=1.3.0
 stups-tokens>=0.7
 wget==3.2
+distutils

--- a/src/app.py
+++ b/src/app.py
@@ -10,11 +10,19 @@ import subprocess
 import sys
 
 import requests
+import locust
+
+from distutils.version import LooseVersion
 
 processes = []
 logging.basicConfig()
 logger = logging.getLogger('bootstrap')
 
+def get_slaves_number(res=None):
+    if LooseVersion("0.8") < LooseVersion(locust.__version__):
+        return len(res.json().get('slaves'))
+    else:
+        return res.json().get('slave_count')
 
 def bootstrap(_return=0):
     """
@@ -94,7 +102,7 @@ def bootstrap(_return=0):
                             logger.info('Checking if all slave(s) are connected.')
                             stats_url = '/'.join([master_url, 'stats/requests'])
                             res = requests.get(url=stats_url)
-                            connected_slaves = res.json().get('slave_count')
+                            connected_slaves = get_slaves_number(res)
 
                             if connected_slaves >= total_slaves:
                                 break

--- a/src/report.py
+++ b/src/report.py
@@ -6,11 +6,11 @@ import os
 from flask import make_response
 
 from jinja2 import Environment, FileSystemLoader
+from distutils.version import LooseVersion
 
 import requests
 import locust
 
-from distutils.version import LooseVersion
 
 WORK_DIR = os.path.dirname(__file__)
 CSV_URL = 'http://0.0.0.0:8089/stats/distribution/csv'

--- a/src/report.py
+++ b/src/report.py
@@ -8,6 +8,9 @@ from flask import make_response
 from jinja2 import Environment, FileSystemLoader
 
 import requests
+import locust
+
+from distutils.version import LooseVersion
 
 WORK_DIR = os.path.dirname(__file__)
 CSV_URL = 'http://0.0.0.0:8089/stats/distribution/csv'
@@ -18,6 +21,12 @@ HTML_REPORT = 'report.html'
 
 logger = logging.getLogger('reporting')
 
+
+def get_slaves_number(res=None):
+    if LooseVersion("0.8") < LooseVersion(locust.__version__):
+        return len(res.json().get('slaves'))
+    else:
+        return res.json().get('slave_count')
 
 def generate_report(distribution_csv, template_file, report_file):
     """

--- a/src/tests/test_bootstrap.py
+++ b/src/tests/test_bootstrap.py
@@ -83,12 +83,12 @@ class TestBootstrap(TestCase):
 
         self.assertFalse(mocked_timeout.called)
         self.assertFalse(mocked_request.called)
-        #self.assertFalse(mocked_dir.called)
+        # self.assertFalse(mocked_dir.called)
         self.assertFalse(mocked_open.called)
         bootstrap()
         self.assertTrue(mocked_timeout.called)
         self.assertTrue(mocked_request.called)
-        #self.assertTrue(mocked_dir.called)
+        # self.assertTrue(mocked_dir.called)
         self.assertTrue(mocked_open.called)
 
     @mock.patch('time.sleep')
@@ -115,12 +115,12 @@ class TestBootstrap(TestCase):
 
         self.assertFalse(mocked_timeout.called)
         self.assertFalse(mocked_request.called)
-        #self.assertFalse(mocked_dir.called)
+        # self.assertFalse(mocked_dir.called)
         self.assertFalse(mocked_open.called)
         bootstrap()
         self.assertTrue(mocked_timeout.called)
         self.assertTrue(mocked_request.called)
-        #self.assertTrue(mocked_dir.called)
+        # self.assertTrue(mocked_dir.called)
         self.assertTrue(mocked_open.called)
 
     def test_invalid_role(self):


### PR DESCRIPTION
see https://github.com/locustio/locust/blob/master/CHANGELOG.md |
specially https://github.com/locustio/locust/pull/305
starting from 0.9 version there is no longer "slave_count" at `/stats/requests` 
instead they provide you the list of slaves=[] , to be prepared to upgrade. 

I can add locust upgrade to latest 0.9 release in this PR or you think it makes sense to do it in separate PR? 

p.s: changed flake8 execution to fail if problem found. 