### PR TITLE
Fail on wrong # of slaves, probe master readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,22 @@ The purpose of this project is to provide a ready and easy-to-use version of [lo
 
 Architecture
 ------------
-Docker-Locust consist of 3 different roles:
+Docker-Locust container can be started in 4 different roles:
 
-- Master: Instance that will run Locust's web interface where you start and stop the load test and see live statistics.
-- Slave: Instance that will simulate users and attack the target url based on user parameters.
-- Controller: Instance that will be run for automatic mode and will download the HTML report at the end of load test.
+- `master`: Runs Locust's web interface where you start and stop the load test and see live statistics.
+- `slave`: Simulates users and attacks the target url based on user parameters.
+- `controller`: Orchestrates Master in automatic mode and downloads reports when the test is over.
+- `standalone`: Automatically starts the above components locally.
 
-This architecture support following type of deployment:
+There are 2 supported run types:
+- Manual: when a user manually starts and stops a test via a Locust Master UI.
+- Automatic: when a test is started by the Controller and runs for a specified time interval. F
 
-- single container (standalone mode): If user have only one single machine.
-- multiple containers (normal mode): If user have more than one machine and want to create bigger load. This type of deployment might be used in docker-swarm or kubernetes case. An example for deployment in different containers can be seen in [docker-compose].
+And there are 2 ways to deploy it:
+- Local deployment (using `standalone` mode or [docker-compose]): when a singe machine can generate enough traffic.
+- Distributed deployment: when multiple machines are required to generate a bigger load. This type of deployment might be used in AWS or Kubernetes.
+An example deployment with different container roles can be found in [docker-compose].
+Using Automatic mode together with Distributed deployment type requires `TOTAL_SLAVES` variable to be set on the `controller` side. 
 
 Key advantages
 --------------

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ And there are 2 ways to deploy it:
 - Local deployment (using `standalone` mode or [docker-compose]): when a singe machine can generate enough traffic.
 - Distributed deployment: when multiple machines are required to generate a bigger load. This type of deployment might be used in AWS or Kubernetes.
 An example deployment with different container roles can be found in [docker-compose].
-Using Automatic mode together with Distributed deployment type requires `TOTAL_SLAVES` variable to be set on the `controller` side. 
+Using Automatic mode together with Distributed deployment requires the `TOTAL_SLAVES` variable to be set on the `controller` side. 
 
 Key advantages
 --------------

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Docker-Locust container can be started in 4 different roles:
 
 There are 2 supported run types:
 - Manual: when a user manually starts and stops a test via a Locust Master UI.
-- Automatic: when a test is started by the Controller and runs for a specified time interval. F
+- Automatic: when a test is started by the Controller and runs for a specified time interval.
 
 And there are 2 ways to deploy it:
 - Local deployment (using `standalone` mode or [docker-compose]): when a singe machine can generate enough traffic.

--- a/example/simple.py
+++ b/example/simple.py
@@ -1,13 +1,11 @@
 from locust import HttpLocust
 from locust import TaskSet
 from locust import task
+
+# For HTML reporting
 from locust.web import app
-
 from src import report
-
-# For reporting
 app.add_url_rule('/htmlreport', 'htmlreport', report.download_report)
-
 
 class SimpleBehavior(TaskSet):
 

--- a/example/simple_post.py
+++ b/example/simple_post.py
@@ -5,11 +5,10 @@ from random import randint
 from locust import HttpLocust
 from locust import TaskSet
 from locust import task
+
+# For HTML reporting
 from locust.web import app
-
 from src import report
-
-# For reporting
 app.add_url_rule('/htmlreport', 'htmlreport', report.download_report)
 
 # Read json file

--- a/src/.#app.py
+++ b/src/.#app.py
@@ -1,0 +1,1 @@
+scherniavsky@shanti.4948

--- a/src/.#app.py
+++ b/src/.#app.py
@@ -1,1 +1,0 @@
-scherniavsky@shanti.4948

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,11 @@ import logging
 import multiprocessing
 import os
 
+import requests
 import signal
 import subprocess
 import sys
-
-import requests
+import time
 
 processes = []
 logging.basicConfig()
@@ -50,6 +50,9 @@ def bootstrap(_return=0):
 
         logger.info('target host: {target}, locust file: {file}, master: {master}, multiplier: {multiplier}'.format(
             target=target_host, file=locust_file, master=master_host, multiplier=multiplier))
+
+        wait_for_master()
+
         for _ in range(multiplier):
             logger.info('Started Process')
             s = subprocess.Popen([
@@ -72,8 +75,8 @@ def bootstrap(_return=0):
                 os.getenv('SLAVE_MUL', multiprocessing.cpu_count()))
             # Default time duration to wait all slaves to be connected is 1 minutes / 60 seconds
             slaves_check_timeout = float(os.getenv('SLAVES_CHECK_TIMEOUT', 60))
-            # Default sleep time interval is 10 seconds
-            slaves_check_interval = float(os.getenv('SLAVES_CHECK_INTERVAL', 5))
+            # Default sleep time interval is 3 seconds
+            slaves_check_interval = float(os.getenv('SLAVES_CHECK_INTERVAL', 3))
             users = int(get_or_raise('USERS'))
             hatch_rate = int(get_or_raise('HATCH_RATE'))
             duration = int(get_or_raise('DURATION'))
@@ -81,72 +84,67 @@ def bootstrap(_return=0):
                 'master url: {url}, users: {users}, hatch_rate: {rate}, duration: {duration}'.format(
                     url=master_url, users=users, rate=hatch_rate, duration=duration))
 
-            for _ in range(0, 5):
-                import time
-                time.sleep(3)
+            wait_for_master()
 
-                res = requests.get(url=master_url)
-                if res.ok:
-                    timeout = time.time() + slaves_check_timeout
-                    connected_slaves = 0
-                    while time.time() < timeout:
-                        try:
-                            logger.info('Checking if all slave(s) are connected.')
-                            stats_url = '/'.join([master_url, 'stats/requests'])
-                            res = requests.get(url=stats_url)
-                            connected_slaves = res.json().get('slave_count')
+            timeout = time.time() + slaves_check_timeout
+            connected_slaves = 0
+            while time.time() < timeout:
+                try:
+                    logger.info('Checking if all slave(s) are connected.')
+                    stats_url = '/'.join([master_url, 'stats/requests'])
+                    res = requests.get(url=stats_url)
+                    connected_slaves = res.json().get('slave_count')
 
-                            if connected_slaves >= total_slaves:
-                                break
-                            else:
-                                logger.info('Currently connected slaves: {con}'.format(con=connected_slaves))
-                                time.sleep(slaves_check_interval)
-                        except ValueError as v_err:
-                            logger.error(v_err.message)
+                    if connected_slaves >= total_slaves:
+                        break
                     else:
-                        logger.warning('Connected slaves:{con} != defined slaves:{dfn}'.format(
-                            con=connected_slaves, dfn=total_slaves))
+                        logger.info('Currently connected slaves: {con}'.format(con=connected_slaves))
 
-                    logger.info('All slaves are succesfully connected! '
-                                'Start load test automatically for {duration} seconds.'.format(duration=duration))
-                    payload = {'locust_count': users, 'hatch_rate': hatch_rate}
-                    res = requests.post(url=master_url + '/swarm', data=payload)
+                except ValueError as v_err:
+                    logger.error(v_err.message)
 
-                    if res.ok:
-                        time.sleep(duration)
-                        requests.get(url=master_url + '/stop')
-                        logger.info('Load test is stopped.')
+                time.sleep(slaves_check_interval)
+            else:
+                logger.error('Connected slaves:{con} < defined slaves:{dfn}'.format(
+                    con=connected_slaves, dfn=total_slaves))
+                raise RuntimeError('The Slaves did not connect in time.')
 
-                        time.sleep(4)
+            logger.info('All slaves are succesfully connected! '
+                        'Start load test automatically for {duration} seconds.'.format(duration=duration))
+            payload = {'locust_count': users, 'hatch_rate': hatch_rate}
+            res = requests.post(url=master_url + '/swarm', data=payload)
 
-                        logging.info('Creating report folder.')
-                        report_path = os.path.join(os.getcwd(), 'reports')
-                        if not os.path.exists(report_path):
-                            os.makedirs(report_path)
+            if res.ok:
+                time.sleep(duration)
+                requests.get(url=master_url + '/stop')
+                logger.info('Load test is stopped.')
 
-                        logger.info('Creating reports...')
-                        for _url in ['requests', 'distribution']:
-                            res = requests.get(url=master_url + '/stats/' + _url + '/csv')
-                            with open(os.path.join(report_path, _url + '.csv'), "wb") as file:
-                                file.write(res.content)
+                time.sleep(4)
 
-                            if _url == 'distribution':
-                                continue
-                            res = requests.get(url=master_url + '/stats/' + _url)
-                            with open(os.path.join(report_path, _url + '.json'), "wb") as file:
-                                file.write(res.content)
+                logging.info('Creating reports folder.')
+                report_path = os.path.join(os.getcwd(), 'reports')
+                if not os.path.exists(report_path):
+                    os.makedirs(report_path)
 
-                        res = requests.get(url=master_url + '/htmlreport')
-                        with open(os.path.join(report_path, 'reports.html'), "wb") as file:
-                            file.write(res.content)
-                        logger.info('Reports have been successfully created.')
-                    else:
-                        logger.error('Locust cannot be started. Please check logs!')
+                logger.info('Creating reports...')
+                for _url in ['requests', 'distribution']:
+                    res = requests.get(url=master_url + '/stats/' + _url + '/csv')
+                    with open(os.path.join(report_path, _url + '.csv'), "wb") as file:
+                        file.write(res.content)
 
-                    break
-                else:
-                    logger.error('Attempt: {attempt}. Locust master might not ready yet.'
-                                 'Status code: {status}'.format(attempt=_, status=res.status_code))
+                    if _url == 'distribution':
+                        continue
+                    res = requests.get(url=master_url + '/stats/' + _url)
+                    with open(os.path.join(report_path, _url + '.json'), "wb") as file:
+                        file.write(res.content)
+
+                res = requests.get(url=master_url + '/htmlreport')
+                with open(os.path.join(report_path, 'reports.html'), "wb") as file:
+                    file.write(res.content)
+                logger.info('Reports have been successfully created.')
+            else:
+                logger.error('Locust cannot be started. Please check logs!')
+
         except ValueError as v_err:
             logger.error(v_err)
 
@@ -164,7 +162,7 @@ def bootstrap(_return=0):
             sys.exit(0)
 
     else:
-        raise RuntimeError('Invalid ROLE value. Valid Options: master, slave, controller.')
+        raise RuntimeError('Invalid ROLE value. Valid Options: master, slave, controller, standalone.')
 
     if _return:
         return
@@ -350,6 +348,31 @@ def kill(signal, frame):
     logger.info('Received KILL signal')
     for s in processes:
         s.kill(s)
+
+
+def wait_for_master():
+    master_host = get_or_raise('MASTER_HOST')
+    master_url = 'http://{master}:8089'.format(master=master_host)
+
+    # Wait for the master to come online during SLAVES_CHECK_TIMEOUT
+    master_check_timeout = float(os.getenv('MASTER_CHECK_TIMEOUT', 60))
+    # Default sleep time interval is 3 seconds
+    master_check_interval = float(os.getenv('MASTER_CHECK_INTERVAL', 3))
+
+    timeout = time.time() + master_check_timeout
+    cnt = 1
+    while time.time() < timeout:
+        try:
+            res = requests.get(url=master_url, timeout=1)
+            if res.ok:
+                logger.info('Locust master is ready.')
+                return
+        except requests.exceptions.ConnectionError:
+            pass
+        logger.warning('Attempt: {attempt}. Locust master is not ready yet.'.format(attempt=cnt))
+        cnt += 1
+        time.sleep(master_check_interval)
+    raise RuntimeError('The master did not start in time.')
 
 
 if __name__ == '__main__':

--- a/src/app.py
+++ b/src/app.py
@@ -107,7 +107,7 @@ def bootstrap(_return=0):
             else:
                 logger.error('Connected slaves:{con} < defined slaves:{dfn}'.format(
                     con=connected_slaves, dfn=total_slaves))
-                raise RuntimeError('The Slaves did not connect in time.')
+                raise RuntimeError('The slaves did not connect in time.')
 
             logger.info('All slaves are succesfully connected! '
                         'Start load test automatically for {duration} seconds.'.format(duration=duration))
@@ -143,7 +143,7 @@ def bootstrap(_return=0):
                     file.write(res.content)
                 logger.info('Reports have been successfully created.')
             else:
-                logger.error('Locust cannot be started. Please check logs!')
+                logger.error('Locust cannot be started. Please check the logs!')
 
         except ValueError as v_err:
             logger.error(v_err)

--- a/src/tests/test_bootstrap.py
+++ b/src/tests/test_bootstrap.py
@@ -38,7 +38,7 @@ class TestBootstrap(TestCase):
                 bootstrap()
                 self.assertFalse(file.called)
                 self.assertFalse(popen.called)
-            self.assertEqual('The Master did not start in time.', str(e.exception))
+            self.assertEqual('The master did not start in time.', str(e.exception))
 
 
     @mock.patch('subprocess.Popen')


### PR DESCRIPTION
This PR does 2 things:
- addresses https://github.com/zalando-incubator/docker-locust/issues/108 (`fail on wrong # of slaves`)
- minimizes this issue when master / slave startup order can't be controlled

It was observed that if slaves start shortly before a master, it takes them much time to reconnect, which:
- sometimes exceeds slaves waiting timeout
- may lead to higher load if slaves connect to the master during a running test

The PR adds master readiness probe on slaves, so they start after a master and don't need to reconnect.